### PR TITLE
Set default udp persistence

### DIFF
--- a/lib/Connection/UdpSocket.php
+++ b/lib/Connection/UdpSocket.php
@@ -38,7 +38,7 @@ class UdpSocket extends InetSocket implements Connection
      * @param int|null $timeout
      * @param bool $persistent
      */
-    protected function connect($host, $port, $timeout, $persistent = False)
+    protected function connect($host, $port, $timeout, $persistent = false)
     {
         $errorNumber = null;
         $errorMessage = null;

--- a/lib/Connection/UdpSocket.php
+++ b/lib/Connection/UdpSocket.php
@@ -38,7 +38,7 @@ class UdpSocket extends InetSocket implements Connection
      * @param int|null $timeout
      * @param bool $persistent
      */
-    protected function connect($host, $port, $timeout, $persistent)
+    protected function connect($host, $port, $timeout, $persistent = False)
     {
         $errorNumber = null;
         $errorMessage = null;


### PR DESCRIPTION
It might make sense to set the default connection handling of the udp protocol to non-persistent.
Apart from having a simpler interface, there might be issues when creating too many persistent connections.
(see here: http://php.net/manual/en/function.pfsockopen.php)