### PR TITLE
Restoring PHP 5.3.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         {"name": "Dominik Liebler", "email": "liebler.dominik@gmail.com"}
     ],
     "require": {
-        "php": ">= 5.4.0"
+        "php": ">= 5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">= 4.4.0"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -19,14 +19,14 @@ class Client
      *
      * @var array
      */
-    private $timings = [];
+    private $timings = array();
 
     /**
      * holds all memory profiles like timings
      *
      * @var array
      */
-    private $memoryProfiles = [];
+    private $memoryProfiles = array();
 
     /**
      * global key namespace
@@ -40,7 +40,7 @@ class Client
      *
      * @var array
      */
-    private $batch = [];
+    private $batch = array();
 
     /**
      * batch mode?
@@ -315,7 +315,7 @@ class Client
     {
         $this->isBatch = false;
         $this->connection->sendMessages($this->batch);
-        $this->batch = [];
+        $this->batch = array();
     }
 
     /**
@@ -324,6 +324,6 @@ class Client
     public function cancelBatch()
     {
         $this->isBatch = false;
-        $this->batch = [];
+        $this->batch = array();
     }
 }

--- a/lib/Connection/InMemory.php
+++ b/lib/Connection/InMemory.php
@@ -10,7 +10,7 @@ use Domnikl\Statsd\Connection as Connection;
  */
 class InMemory implements Connection
 {
-    private $messages = [];
+    private $messages = array();
 
     /**
      * {@inheritdoc}
@@ -33,7 +33,7 @@ class InMemory implements Connection
      */
     public function clear()
     {
-        $this->messages = [];
+        $this->messages = array();
     }
 
     /**

--- a/lib/Connection/InetSocket.php
+++ b/lib/Connection/InetSocket.php
@@ -148,7 +148,7 @@ abstract class InetSocket implements Connection
     private function cutIntoMtuSizedMessages(array $messages)
     {
         $index = 0;
-        $sizedMessages = [];
+        $sizedMessages = array();
         $packageLength = 0;
 
         foreach ($messages as $message) {

--- a/tests/unit/ConnectionMock.php
+++ b/tests/unit/ConnectionMock.php
@@ -13,7 +13,7 @@ class ConnectionMock implements Connection
     /**
      * @var array
      */
-    public $messages = [];
+    public $messages = array();
 
     /**
      * @var bool


### PR DESCRIPTION
Hello, 

PHP 5.3.27 had a maintenance release on 14 Aug 2014 which is only 13 months old.  It can be hard for many companies/products/installations to keep up-to-date with releases of PHP, which means that the longer you can support older versions of PHP (without degrading your library) the better.  (Our company for example is still on PHP 5.3.10 - yeah, I know).

Auditing the changes, it appears that the only PHP >= 5.4 feature used was the shorthand for dereferencing arrays ( = []).  Since this will always be supported with = array() syntax, I suggest you keep the older syntax and re-support PHP 5.3 (until such a time comes that you must use a feature of PHP that is > 5.3)

Regards, and thanks for providing this library.
-Tim