### PR TITLE
Remove timing cast to int

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -110,7 +110,7 @@ class Client
      */
     public function timing($key, $value, $sampleRate = 1)
     {
-        $this->send($key, (int) $value, 'ms', $sampleRate);
+        $this->send($key, $value, 'ms', $sampleRate);
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -135,7 +135,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->endTiming($key);
 
         // ranges between 1000 and 1001ms
-        $this->assertRegExp('/^test\.foo\.bar:1[0-9]\|ms$/', $this->connection->getLastMessage());
+        $this->assertRegExp('/^test\.foo\.bar:1[0-9](.[0-9]+)?\|ms$/', $this->connection->getLastMessage());
     }
 
     public function testEndTimingReturnsTiming()
@@ -161,7 +161,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->endTiming('foo.baz');
 
         // ranges between 1000 and 1001ms
-        $this->assertRegExp('/^test\.foo\.baz:1[0-9]\|ms\|@0.3$/', $this->connection->getLastMessage());
+        $this->assertRegExp('/^test\.foo\.baz:1[0-9](.[0-9]+)?\|ms\|@0.3$/', $this->connection->getLastMessage());
     }
 
     public function testTimeClosure()


### PR DESCRIPTION
Casting the timing to an int, means you loose precision and also small increments gets rounded to 0.
(I use the timing to profile parts of an application as well as db or api calls, and most of the time I get a 0 value instead of a float in ms.)