### PR TITLE
Remove count cast to int

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -95,13 +95,13 @@ class Client
      * sends a count to statsd
      *
      * @param string $key
-     * @param int $value
+     * @param int|float $value
      * @param int $sampleRate (optional) the default is 1
      * @param array $tags
      */
     public function count($key, $value, $sampleRate = 1, $tags = [])
     {
-        $this->send($key, (int) $value, 'c', $sampleRate, $tags);
+        $this->send($key, $value, 'c', $sampleRate, $tags);
     }
 
     /**

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -47,6 +47,15 @@ class ClientTest extends TestCase
         );
     }
 
+    public function testCountWithFloatValue()
+    {
+        $this->client->count('foo.bar', 100.45);
+        $this->assertEquals(
+            'test.foo.bar:100.45|c',
+            $this->connection->getLastMessage()
+        );
+    }
+
     /**
      * @group sampling
      */


### PR DESCRIPTION
Casting `count` to `int` make this type of metric unusable for tracking event-based small float values.
I use `count` to track small payment operations.