### PR TITLE
Check client-level sample rate before sampling data

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -253,6 +253,11 @@ class Client
      */
     private function send($key, $value, $type, $sampleRate, $tags = [])
     {
+        // override sampleRate if all metrics should be sampled
+        if ($this->sampleRateAllMetrics < 1) {
+            $sampleRate = $this->sampleRateAllMetrics;
+        }
+
         if (mt_rand() / mt_getrandmax() > $sampleRate) {
             return;
         }
@@ -262,11 +267,6 @@ class Client
         }
 
         $message = $key . ':' . $value . '|' . $type;
-
-        // overwrite sampleRate if all metrics should be sampled
-        if ($this->sampleRateAllMetrics < 1) {
-            $sampleRate = $this->sampleRateAllMetrics;
-        }
 
         if ($sampleRate < 1) {
             $sampledData = $message . '|@' . $sampleRate;

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -61,10 +61,12 @@ class ClientTest extends TestCase
      */
     public function testCountWithSamplingRate()
     {
-        $client = new Client($this->connection, 'test', 1 / 5);
-        $client->count('foo.baz', 100, 1);
+        $client = new Client($this->connection, 'test', 9 / 10);
+        for ($i = 0; $i < 10; $i++) {
+            $client->count('foo.baz', 100, 1);
+        }
         $this->assertEquals(
-            'test.foo.baz:100|c|@0.2',
+            'test.foo.baz:100|c|@0.9',
             $this->connection->getLastMessage()
         );
     }
@@ -74,10 +76,12 @@ class ClientTest extends TestCase
      */
     public function testCountWithSamplingRateAndTags()
     {
-        $client = new Client($this->connection, 'test', 1 / 5);
-        $client->count('foo.baz', 100, 1, ['tag' => 'value']);
+        $client = new Client($this->connection, 'test', 9 / 10);
+        for ($i = 0; $i < 10; $i++) {
+            $client->count('foo.baz', 100, 1, ['tag' => 'value']);
+        }
         $this->assertEquals(
-            'test.foo.baz:100|c|@0.2|#tag:value',
+            'test.foo.baz:100|c|@0.9|#tag:value',
             $this->connection->getLastMessage()
         );
     }
@@ -96,10 +100,12 @@ class ClientTest extends TestCase
      */
     public function testIncrementWithSamplingRate()
     {
-        $client = new Client($this->connection, 'test', 0.3);
-        $client->increment('foo.baz', 1);
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->increment('foo.baz', 1);
+        }
         $this->assertEquals(
-            'test.foo.baz:1|c|@0.3',
+            'test.foo.baz:1|c|@0.9',
             $this->connection->getLastMessage()
         );
     }
@@ -109,10 +115,12 @@ class ClientTest extends TestCase
      */
     public function testIncrementWithSamplingRateAndTags()
     {
-        $client = new Client($this->connection, 'test', 0.3);
-        $client->increment('foo.baz', 1, ['tag' => 'value']);
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->increment('foo.baz', 1, ['tag' => 'value']);
+        }
         $this->assertEquals(
-            'test.foo.baz:1|c|@0.3|#tag:value',
+            'test.foo.baz:1|c|@0.9|#tag:value',
             $this->connection->getLastMessage()
         );
     }
@@ -131,10 +139,12 @@ class ClientTest extends TestCase
      */
     public function testDecrementWithSamplingRate()
     {
-        $client = new Client($this->connection, 'test', 0.2);
-        $client->decrement('foo.baz', 1);
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->decrement('foo.baz', 1);
+        }
         $this->assertEquals(
-            'test.foo.baz:-1|c|@0.2',
+            'test.foo.baz:-1|c|@0.9',
             $this->connection->getLastMessage()
         );
     }
@@ -144,10 +154,12 @@ class ClientTest extends TestCase
      */
     public function testDecrementWithSamplingRateAndTags()
     {
-        $client = new Client($this->connection, 'test', 0.2);
-        $client->decrement('foo.baz', 1, ['tag' => 'value']);
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->decrement('foo.baz', 1, ['tag' => 'value']);
+        }
         $this->assertEquals(
-            'test.foo.baz:-1|c|@0.2|#tag:value',
+            'test.foo.baz:-1|c|@0.9|#tag:value',
             $this->connection->getLastMessage()
         );
     }
@@ -167,10 +179,12 @@ class ClientTest extends TestCase
      */
     public function testTimingWithSamplingRate()
     {
-        $client = new Client($this->connection, 'test', 0.1);
-        $client->timing('foo.baz', 2000, 1);
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->timing('foo.baz', 2000, 1);
+        }
         $this->assertEquals(
-            'test.foo.baz:2000|ms|@0.1',
+            'test.foo.baz:2000|ms|@0.9',
             $this->connection->getLastMessage()
         );
     }
@@ -203,13 +217,15 @@ class ClientTest extends TestCase
      */
     public function testStartEndTimingWithSamplingRate()
     {
-        $client = new Client($this->connection, 'test', 0.3);
-        $client->startTiming('foo.baz');
-        usleep(10000);
-        $client->endTiming('foo.baz');
+        $client = new Client($this->connection, 'test', 0.9);
+        for ($i = 0; $i < 10; $i++) {
+            $client->startTiming('foo.baz');
+            usleep(10000);
+            $client->endTiming('foo.baz');
+        }
 
         // ranges between 1000 and 1001ms
-        $this->assertRegExp('/^test\.foo\.baz:1[0-9](.[0-9]+)?\|ms\|@0.3$/', $this->connection->getLastMessage());
+        $this->assertRegExp('/^test\.foo\.baz:1[0-9](.[0-9]+)?\|ms\|@0.9$/', $this->connection->getLastMessage());
     }
 
     public function testTimeClosure()


### PR DESCRIPTION
Sample rates can be [overridden at the client level](https://github.com/domnikl/statsd-php/blob/master/lib/Client.php#L64-L69). However, this currently isn't working because [the code that actually applies the sampling](https://github.com/domnikl/statsd-php/blob/master/lib/Client.php#L256-L258) is evaluated before [we even look at the client override](https://github.com/domnikl/statsd-php/blob/master/lib/Client.php#L266-L269). 

This PR fixes the issue by simply moving the sample rate override check above the code that does the actual sampling.