### PR TITLE
Avoid computational expensive mt_rand()

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -253,7 +253,7 @@ class Client
      */
     private function send($key, $value, $type, $sampleRate, $tags = [])
     {
-        if (mt_rand() / mt_getrandmax() > $sampleRate) {
+        if ($sampleRate < 1 && mt_rand() / mt_getrandmax() > $sampleRate) {
             return;
         }
 


### PR DESCRIPTION
If the sampling rate is 1 or even bigger there is no change the condition `mt_rand() / mt_getrandmax() > $sampleRate` will apply.
This saves time because mt_rand is computational expensive.