### PR TITLE
Fix phpunit coverage generation error

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,9 @@
             <directory>tests/unit</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./lib</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
On PHP 7.0 with the required phpunit version, the coverage generation
fails with:

`Error: Incorrect whitelist config, no code coverage will be generated.`

Adding as whitelist coverage config fixes this problem.