### PR TITLE
Don't send an empty message or connect if the batch/messages array is empty

### DIFF
--- a/lib/Connection/InetSocket.php
+++ b/lib/Connection/InetSocket.php
@@ -126,6 +126,10 @@ abstract class InetSocket implements Connection
      */
     public function sendMessages(array $messages)
     {
+        if (count($messages) === 0) {
+            return;
+        }
+
         if (!$this->isConnected()) {
             $this->connect($this->host, $this->port, $this->timeout, $this->persistent);
         }

--- a/tests/unit/Connection/TcpSocketTest.php
+++ b/tests/unit/Connection/TcpSocketTest.php
@@ -29,7 +29,7 @@ class TcpSocketTest extends TestCase
 
     /**
      * @expectedException \Domnikl\Statsd\Connection\TcpSocketException
-     * @expectedExceptionMessage Couldn't connect to host "localhost:66000": Connection refused
+     * @expectedExceptionMessage Couldn't connect to host "localhost:66000": 
      */
     public function testThrowsExceptionWhenTryingToConnectToNotExistingServer()
     {


### PR DESCRIPTION
Currently, if you call `InetSocket::sendMessages()` (inherited in the TCP/UDP connections) with an empty array, a line delimiter is sent to the socket. This is considered an empty message in my context.  This PR fixed that behavior by returning from `sendMessages()` (and avoiding a connection) if the passed array is empty.  In my case I am starting a batch, passing the client to another object, then ending it without knowing how many messages were added to the batch.

The newline is caused by `cutIntoMtuSizedPackets()`, which uses `$message = join(self::LINE_DELIMITER, $messages) . self::LINE_DELIMITER;` on an empty `$messages` array.  I think this behavior is probably OK if you intend to send one empty message, but when sending an array, it seems reasonable that it should be 0 or more messages.

Thanks for the great library!