### PR TITLE
Disabled msg fragmentation for UDP, added tiny sleep

### DIFF
--- a/lib/Connection/InetSocket.php
+++ b/lib/Connection/InetSocket.php
@@ -142,8 +142,26 @@ abstract class InetSocket implements Connection
      */
     private function cutIntoMtuSizedPackets(array $messages)
     {
-        $message = join(self::LINE_DELIMITER, $messages) . self::LINE_DELIMITER;
-        $packets = str_split($message, $this->maxPayloadSize);
+
+        if ($this->allowFragmentation()) {
+            $message = join(self::LINE_DELIMITER, $messages) . self::LINE_DELIMITER;
+            return str_split($message, $this->maxPayloadSize);
+        }
+
+        $delimiterLen = strlen(self::LINE_DELIMITER);
+        $packets = [];
+        $packet = '';
+        foreach ($messages as $message) {
+            if (strlen($packet) + strlen($message) + $delimiterLen > $this->maxPayloadSize) {
+                $packets[] = $packet;
+                $packet = '';
+            }
+            $packet .= $message . self::LINE_DELIMITER;
+        }
+
+        if (strlen($packet) > 0) {
+            $packets[] = $packet;
+        }
 
         return $packets;
     }
@@ -176,4 +194,11 @@ abstract class InetSocket implements Connection
      * @return int
      */
     abstract protected function getProtocolHeaderSize();
+
+    /**
+     * whether or not message fragmention should be allowed
+     *
+     * @return bool
+     */
+    abstract protected function allowFragmentation();
 }

--- a/lib/Connection/TcpSocket.php
+++ b/lib/Connection/TcpSocket.php
@@ -97,4 +97,14 @@ class TcpSocket extends InetSocket implements Connection
     {
         return self::HEADER_SIZE;
     }
+
+    /**
+     * message fragmention should be allowed on TCP to maximize throughput
+     *
+     * @return bool
+     */
+    protected function allowFragmentation()
+    {
+        return true;
+    }
 }

--- a/lib/Connection/UdpSocket.php
+++ b/lib/Connection/UdpSocket.php
@@ -49,6 +49,9 @@ class UdpSocket extends InetSocket implements Connection
     {
         // suppress all errors
         @fwrite($this->socket, $message);
+
+        // sleeping for 10 millionths of a second dramatically improves UDP reliability
+        usleep(10);
     }
 
     /**
@@ -102,5 +105,17 @@ class UdpSocket extends InetSocket implements Connection
     protected function getProtocolHeaderSize()
     {
         return self::HEADER_SIZE;
+    }
+
+    /**
+     * message fragmention should not be allowed on UDP because packets
+     * regularly arrive out-of-order, and if they are not split evenly on a
+     * line delimiter, they will be combined in strange ways.
+     *
+     * @return bool
+     */
+    protected function allowFragmentation()
+    {
+        return false;
     }
 }


### PR DESCRIPTION
I'm planning to use this library in a fairly high throughput application over UDP (5-10k msg/sec), and after seeing issue #58, I spent a bunch of time testing the library's UDP Socket Connection over connections ranging from loopback to Windows laptop tethered to a cellphone, through two VPNs.

What I've found is that with the current implementation, in batch mode with a large batch (~10k msgs), about 20% of the packets are dropped before reaching the destination and 5% of the remaining packets are corrupted due to fragmented messages arriving out-of-order (I observed this regularly, even over a loopback).

Both of the problems I've mentioned are sort of "the price you pay when using UDP", but that doesn't mean we can't improve them.

First, I tried to figure out why such a high percentage of packets were being lost (tuning kernel parameters had little effect).  I found that by adding a 10-millionths-of-a-second delay after the socket `fwrite()`, I was getting nearly 100% of the lines.  This delay wastes one second per 100,000 messages, although the current approach wastes 0 seconds and 20,000 messages per 100,000 messages are lost in my scenario :).

Now I was getting all the data, but the lines were still coming in fragmented, so I implemented an abstract method `InetSocket::allowFragmentation()`, which is `true` for TCP and `false` for UDP, and I implemented a non-fragmenting packing algorithm which packs as many messages into a packet as will fit, without splitting them (you can still send a message larger than the MTU, but there's nothing we can do to make that reliable).

Now, the packets are still arriving out-of-order, but that's OK, because they are not split up, just rearranged.  Given the extra space left unused in the UDP packet's MTU, I was also able to reliably receive 100% of the data, even in my worst-case scenario.  Mission accomplished!

Thanks @robertology reporting this issue and for providing an example of the corruption that I could use to reproduce the issue!