### PR TITLE
Added buildSampledData

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -281,7 +281,7 @@ class Client
      * @param array $tags
      * @return string $sampledData
      */
-    public function buildSampledData(string $key, $value, string $type, float $sampleRate, array $tags = [])
+    public function buildSampledData(string $key, $value, string $type, float $sampleRate, array $tags = []): string
     {
         $sampledData = null;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,6 +262,30 @@ class Client
             return;
         }
 
+        $sampledData = $this->buildSampledData($key, $value, $type, $sampleRate, $tags);
+
+        if (!$this->isBatch) {
+            $this->connection->send($sampledData);
+        } else {
+            $this->batch[] = $sampledData;
+        }
+    }
+
+    /**
+     * Prepares a statsd compatible string from given data and parameters
+     *
+     * @param string $key
+     * @param int|float|string $value
+     * @param string $type
+     * @param float $sampleRate
+     * @param array $tags
+     * 
+     * @return string $sampledData
+     */
+    public function buildSampledData(string $key, $value, string $type, float $sampleRate, array $tags = [])
+    {
+        $sampledData = null;
+
         if (strlen($this->namespace) !== 0) {
             $key = $this->namespace . '.' . $key;
         }
@@ -285,11 +309,7 @@ class Client
             $sampledData .= join(',', $tagArray);
         }
 
-        if (!$this->isBatch) {
-            $this->connection->send($sampledData);
-        } else {
-            $this->batch[] = $sampledData;
-        }
+        return $sampledData;
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -279,7 +279,6 @@ class Client
      * @param string $type
      * @param float $sampleRate
      * @param array $tags
-     * 
      * @return string $sampledData
      */
     public function buildSampledData(string $key, $value, string $type, float $sampleRate, array $tags = [])

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -303,4 +303,13 @@ class ClientTest extends TestCase
         $message = $this->connection->getLastMessage();
         $this->assertEquals('test.barfoo:666|s|#tag:value,tag2:value2', $message);
     }
+
+    public function testBuildSampledData()
+    {
+        $sampledData = $this->client->buildSampledData("a.b", 15, 'c', 1.1 , ['a', 'b'=>'c']);
+        $this->assertEquals('test.a.b:15|c|#0:a,b:c', $sampledData);
+        $this->client->setNamespace('foobar');
+        $sampledData = $this->client->buildSampledData("c.d", 2, 'ms', 1.1 , []);
+        $this->assertEquals('foobar.c.d:2|ms', $sampledData);
+    }
 }

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -306,10 +306,10 @@ class ClientTest extends TestCase
 
     public function testBuildSampledData()
     {
-        $sampledData = $this->client->buildSampledData("a.b", 15, 'c', 1.1 , ['a', 'b'=>'c']);
+        $sampledData = $this->client->buildSampledData("a.b", 15, 'c', 1.1, ['a', 'b'=>'c']);
         $this->assertEquals('test.a.b:15|c|#0:a,b:c', $sampledData);
         $this->client->setNamespace('foobar');
-        $sampledData = $this->client->buildSampledData("c.d", 2, 'ms', 1.1 , []);
-        $this->assertEquals('foobar.c.d:2|ms', $sampledData);
+        $sampledData = $this->client->buildSampledData("c.d", 2, 'ms', 0.1);
+        $this->assertEquals('foobar.c.d:2|ms|@0.1', $sampledData);
     }
 }


### PR DESCRIPTION
I added this method as I am extending this library and want to "custom" format string before actually sending it to connection. 

`send` being a private method can not be extended, hence added this public method so I can actually override this to do something (such as debug, modify, or add more calculations) before sending the metrics out to real connection.