### PR TITLE
Catch all errors

### DIFF
--- a/src/Connection/TcpSocket.php
+++ b/src/Connection/TcpSocket.php
@@ -34,7 +34,7 @@ class TcpSocket extends InetSocket implements Connection
             parent::send($message);
         } catch (TcpSocketException $e) {
             throw $e;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // ignore it: stats logging failure shouldn't stop the whole app
         }
     }

--- a/src/Connection/UdpSocket.php
+++ b/src/Connection/UdpSocket.php
@@ -32,7 +32,7 @@ class UdpSocket extends InetSocket implements Connection
     {
         try {
             parent::send($message);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // ignore it: stats logging failure shouldn't stop the whole app
         }
     }


### PR DESCRIPTION
I received a fatal error when running unit tests:

expects parameter 1 to be resource, bool given 
`"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): fwrite() expects parameter 1 to be resource, bool given at /var/www/html/vendor/domnikl/statsd/src/Connection/UdpSocket.php:50)`

This will solve this issue