### PR TITLE
Make travis green again

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,7 +22,7 @@ jobs:
         coverage: xdebug #optional
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest --no-interaction
+      run: composer update --prefer-dist --no-progress --no-interaction
 
     - name: phpcs
       run: vendor/bin/phpcs -s --standard=vendor/flyeralarm/php-code-validator/ruleset.xml src/ tests/

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9",
         "flyeralarm/php-code-validator": "^3.2",
-        "vimeo/psalm": "^3.4"
+        "vimeo/psalm": "^4.1"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -34,7 +34,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />


### PR DESCRIPTION
On this PR we're:
- Delete --no-suggest flag. That flag seems intended for development only, so we can't make use of it on travis
- Remove testing againts PHP 8. Some dependency isn't ready yet, I think it's better to add it to test when all dependency is ready