### PR TITLE
Add abandoned key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,6 @@
         "psr-4": {
             "Domnikl\\Test\\Statsd\\": "tests/unit"
         }
-    }
+    },
+    "abandoned": "slickdeals/statsd"
 }


### PR DESCRIPTION
Added the abandoned key to composer.json to redirect them to the Slickdeals project. I was also going to add something to the READMe, but wasn't sure exactly what you would want to say, so I'll leave that for you.

Thanks for creating a great library and allowing us to continue maintaining it!